### PR TITLE
REMOVE when updating LLVM

### DIFF
--- a/lib/Transforms/IPO/IPO.cpp
+++ b/lib/Transforms/IPO/IPO.cpp
@@ -116,7 +116,7 @@ void LLVMAddIPSCCPPass(LLVMPassManagerRef PM) {
 
 void LLVMAddInternalizePass(LLVMPassManagerRef PM, unsigned AllButMain) {
   auto PreserveMain = [=](const GlobalValue &GV) {
-    return AllButMain && GV.getName() == "main";
+    return AllButMain && (GV.getName() == "main" || GV.getName() == "__llair_main" || GV.getName() == "_Z12__llair_mainv");
   };
   unwrap(PM)->add(createInternalizePass(PreserveMain));
 }


### PR DESCRIPTION
Temporary fix to internalizing the non-main top-level function.
Should be removed once LLVM is upgraded to include
https://reviews.llvm.org/D62456 and we can extend the OCaml bindings
to it.